### PR TITLE
support_op  not initialized

### DIFF
--- a/core/include/serializer.hpp
+++ b/core/include/serializer.hpp
@@ -86,8 +86,8 @@ public:
     {
         if (op_load_map_.count(op_name))
             return false;
-
         op_load_map_[op_name] = load_func;
+        support_op.emplace_back(op_name);
         return true;
     }
 


### PR DESCRIPTION
修复新增的support_op未初始化导致转换失败的问题。