### PR TITLE
[onnx] bug fix: 1. unexpected converting crash; 2. wrong value of param.end for op "slice"; 3. wrong tensor data type

### DIFF
--- a/tools/onnx/onnx_serializer.cpp
+++ b/tools/onnx/onnx_serializer.cpp
@@ -552,10 +552,9 @@ bool OnnxSerializer::LoadNode(StaticGraph* graph, StaticNode* node, const onnx::
                 continue;
             }
             if (typeid(StaticTensor) == typeid(*tensor)) {
-                /* Note: StaticTensor has no member "mem_addr" */
-                LOG_WARN() << "[WARN] unexcepted runtime StaticTensor: " << tensor->name;
-                LOG_WARN() << ", tensor dims: " << tensor->dims.size();
-                LOG_WARN() << ", memory size: " << tensor->mem_size << "\n";
+                /* Add StaticTensor to node directly, since it has no member "mem_addr" */
+                AddNodeInputTensor(node, tensor);
+                node_name[tensor->name] = node_name[tensor->name] + 1;
                 continue;
             }
 
@@ -570,7 +569,7 @@ bool OnnxSerializer::LoadNode(StaticGraph* graph, StaticNode* node, const onnx::
                 tensor_size *= dims[t];
             }
             SetTensorDim(new_tensor, dims);
-            SetTensorDataType(new_tensor, DataType::GetTypeID("float32"));
+            SetTensorDataType(new_tensor, tensor->data_type);
             tensor_size = 4 * tensor_size;
             SetTensorSize(tensor, tensor_size);
             uint8_t* mem_buf = ( uint8_t* )std::malloc(tensor_size);

--- a/tools/onnx/onnx_serializer.cpp
+++ b/tools/onnx/onnx_serializer.cpp
@@ -1421,7 +1421,8 @@ static bool LoadOnnxSlice(StaticGraph* graph, StaticNode* node, const onnx::Node
         param.begin = (int)(*(int64_t*)(GetConstTensorBuffer(node_tensor)));
 
         node_tensor = FindTensor(graph, onnx_node.input(2));
-        param.end = (int)(*(int64_t*)(GetConstTensorBuffer(node_tensor)));
+        int64_t end_ = *(int64_t*)(GetConstTensorBuffer(node_tensor));
+        param.end = end_ < INT_MAX ? (int)end_ : INT_MAX;
 
         if (onnx_node.input_size() >= 4)
         {

--- a/tools/onnx/onnx_serializer.cpp
+++ b/tools/onnx/onnx_serializer.cpp
@@ -551,7 +551,14 @@ bool OnnxSerializer::LoadNode(StaticGraph* graph, StaticNode* node, const onnx::
                 AddNodeInputTensor(node, tensor);
                 continue;
             }
-            
+            if (typeid(StaticTensor) == typeid(*tensor)) {
+                /* Note: StaticTensor has no member "mem_addr" */
+                LOG_WARN() << "[WARN] unexcepted runtime StaticTensor: " << tensor->name;
+                LOG_WARN() << ", tensor dims: " << tensor->dims.size();
+                LOG_WARN() << ", memory size: " << tensor->mem_size << "\n";
+                continue;
+            }
+
             std::string new_tensor_name  = tensor->name + "_" + std::to_string(node_name[tensor->name]);
             new_tensor = CreateStaticConstTensor(graph, new_tensor_name);
             std::vector<int> dims = tensor->dims;


### PR DESCRIPTION
As title,
1. the unexpected converting crash is caused by calling GetConstTensorBuffer() with StaticTensor ptr, which doesn't have member "mem_addr".
https://github.com/OAID/Tengine-Convert-Tools/blob/51ddcda084035210acb1addfe3b1a0343475c9f5/tools/onnx/onnx_serializer.cpp#L541
https://github.com/OAID/Tengine-Convert-Tools/blob/51ddcda084035210acb1addfe3b1a0343475c9f5/tools/onnx/onnx_serializer.cpp#L570
2. the dumplicated static const tensor type should be the same as the origin one:
https://github.com/OAID/Tengine-Convert-Tools/blob/51ddcda084035210acb1addfe3b1a0343475c9f5/tools/onnx/onnx_serializer.cpp#L566
3. fix wrong value(-1, which actually should be INT_MAX) of param.end for op "slice";