### PR TITLE
Optimize out Split op during ncnn2tengine conversion

### DIFF
--- a/tools/include/ncnn_serializer.hpp
+++ b/tools/include/ncnn_serializer.hpp
@@ -104,6 +104,7 @@ protected:
     void CreateInputNode(StaticGraph* graph, const std::vector<NcnnNode>& nodelist,
                          const std::vector<NcnnParam>& paramlist);
     bool vstr_is_float(const char vstr[16]);
+    void remove_ncnn_split(std::vector<NcnnNode>& nodelist);
 
     int read(void* buf, int size);
 


### PR DESCRIPTION
Tengine quantize tool does not support Split op in the model, add a simple graph optimizer to remove split ops.